### PR TITLE
ci(renovate): group controller-runtime with the Kubernetes libraries

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,8 +31,14 @@
     },
     {
       "description": "Disable updates for own images",
-      "matchDepPatterns": ["^ghcr.io/lexfrei/", "^docker.io/lexfrei/"],
+      "matchPackageNames": ["ghcr.io/lexfrei/**", "docker.io/lexfrei/**"],
       "enabled": false
+    },
+    {
+      "description": "Keep controller-runtime in lockstep with the Kubernetes libraries (a split bump breaks compilation: controller-runtime vX needs a matching client-go)",
+      "groupName": "kubernetes",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["sigs.k8s.io/controller-runtime", "k8s.io/**"]
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Group `controller-runtime` with the `k8s.io/*` monorepo under one `kubernetes` renovate group so they always bump together — a split bump breaks compilation (controller-runtime vX needs a matching client-go), which is exactly what happened with the separate controller-runtime / k8s-monorepo PRs.

Also modernizes the own-images rule from the deprecated `matchDepPatterns` to `matchPackageNames` globs.

Config-only change.